### PR TITLE
Add IAMDevBox PKCE Generator and JWT Decoder tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@
 * [OIDC Playground](https://oidc-playground.compile7.org/)
 * [OIDC Debugger](https://oidcdebugger.com/) - Web-based tool for testing OIDC authorization requests
 * [OpenID Connect Conformance Suite](https://openid.net/certification/testing/) - Official OIDC provider conformance test suite
+* [IAMDevBox PKCE Generator](https://www.iamdevbox.com/tools/pkce-generator/) - Online PKCE code_verifier and code_challenge generator with S256/plain support
 
 ### JWT
 * [jwt.io](https://jwt.io/) - JWT debugger and library directory by Auth0
@@ -222,6 +223,7 @@
 * [token.dev](https://token.dev/) - Modern JWT debugger with a clean interface
 * [mkjwk.org](https://mkjwk.org/) - JSON Web Key (JWK) generator
 * [jwt-cli](https://github.com/mike-engel/jwt-cli) - Command-line JWT decoder/encoder (Rust)
+* [IAMDevBox JWT Decoder](https://www.iamdevbox.com/tools/jwt-decode/) - Browser-based JWT decoder with header/payload/signature analysis
 
 ### CLI
 * [oauth2c](https://github.com/cloudentity/oauth2c) - Command-line OAuth 2.0 client supporting all grant types, PKCE, DPoP, mTLS


### PR DESCRIPTION
Adds two free browser-based OAuth/OIDC developer tools:

- **PKCE Generator** (Playground section) - Generates code_verifier and code_challenge pairs with S256/plain method support. Useful for testing OAuth 2.1 PKCE flows.
- **JWT Decoder** (JWT section) - Decodes JWT tokens in the browser with header, payload, and signature analysis. No data sent to server.

I'm the author of these tools. Both run entirely client-side with no backend dependencies.