### PR TITLE
Add new resources on GitHub Actions OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@
 * [What's OAuth2 Anyway? by Roman Glushko](https://www.romaglushko.com/blog/whats-aouth2/)
 * [How OpenID Connect Works by OpenID Foundation](https://openid.net/developers/how-connect-works/)
 * [OpenID Connect (OAuth.com) by Aaron Parecki](https://www.oauth.com/oauth2-servers/openid-connect/)
+* [GitHub Actions OIDC – Non-Human Identities and Secretless Authentication](https://eparon.me/posts/2026-02-28-oidc-gh-actions-p1/)
+* [Secret-less authentication towards APIs with GitHub Actions OIDC and Envoy Proxy](https://eparon.me/posts/2026-03-24-oidc-gh-actions-p2/)
 
 ## Book
 * [OAuth 2 in Action](https://www.manning.com/books/oauth-2-in-action)


### PR DESCRIPTION
## What

Adds two articles to the Article section covering OIDC applied to CI/CD workload identity:

- Part 1: Explains non-human identities, how OIDC layers on top of OAuth 2.0, and how GitHub Actions issues scoped JWT tokens for secret-less authentication — no stored credentials.
- Part 2: Practical guide to validating those tokens at the API boundary using Envoy Proxy both for authentication (authN) and authorization (authZ), a threat model, as well as a companion GitHub repository with a full lab setup.

## Why

Both articles sit squarely in the OIDC space — they cover token issuance, JWT validation, and the trust model between an OIDC provider (GitHub) and a relying party (Envoy). They add a workload identity angle that isn't currently represented in the Article section.

## Links

- Part 1: https://eparon.me/posts/2026-02-28-oidc-gh-actions-p1/
- Part 2: https://eparon.me/posts/2026-03-24-oidc-gh-actions-p2/
- Companion repo: https://github.com/eparon/oidc-secure-api-github-actions

---

Happy to take along any suggestions/edits that might be needed prior to merging.