### PR TITLE
Add Authagonal to Server Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@
 * [ZITADEL](https://zitadel.com/) - Cloud-native identity management with OAuth 2.0 and OIDC (Go)
 * [Logto](https://logto.io/) - Developer-friendly, open-source Auth0 alternative with OIDC support (TypeScript)
 * [Casdoor](https://casdoor.org/) - UI-first IAM platform supporting OAuth 2.0, OIDC, SAML, CAS, and more (Go)
+* [Authagonal](https://github.com/authagonal/authagonal) - Self-hosted OAuth 2.0, OIDC, and SAML 2.0 authentication server, deployable as a Docker image or embedded as an ASP.NET Core library (.NET)
 
 ## Client Library
 


### PR DESCRIPTION
Adds [Authagonal](https://github.com/authagonal/authagonal) to the Server Implementation section.

Authagonal is an open-source, self-hostable OAuth 2.0 / OpenID Connect / SAML 2.0 authentication server for .NET. It runs as a single Docker image or can be embedded as an ASP.NET Core library, and supports OIDC federation, SCIM provisioning, MFA, and dynamic client registration. MIT licensed.

Entry follows the existing list format and is placed in the Server Implementation section.